### PR TITLE
add replace reducer

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,12 @@ module.exports = function createStore (reducer, initialState) {
     listener = cb
   }
 
+  function replaceReducer (next) {
+    if (typeof next !== 'function') throw new Error('new reducer must be a function')
+
+    reducer = next
+  }
+
   function getState () {
     return state
   }
@@ -31,6 +37,7 @@ module.exports = function createStore (reducer, initialState) {
   return {
     dispatch: dispatch,
     subscribe: subscribe,
-    getState: getState
+    getState: getState,
+    replaceReducer: replaceReducer
   }
 }

--- a/test.js
+++ b/test.js
@@ -94,3 +94,17 @@ test('missing type fails', function (t) {
 
   t.end()
 })
+
+test('replace a reducer', function (t) {
+  var store = createStore(function () {})
+  store.replaceReducer(function reducer (state, action) {
+    if (action.type === 'example') {
+      return { example: action.example }
+    }
+  })
+  store.dispatch({ type: 'example', example: false })
+  var state = store.getState()
+  t.ok(state)
+  t.equal(state.example, false)
+  t.end()
+})


### PR DESCRIPTION
This adds `replaceReducer` to the API. From what I can tell it's just there to allow post-hoc changes to the reducer, so might as well include for completeness yeah?